### PR TITLE
Support for using sitemap references in CTA destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ In your `data/cta.yml` (or JSON):
   url: "http://absolute.url"
 ```
 
+If you prefer, you can link using a sitemap descriptor instead - meaning any item defined in your middelman site.
+
+```json
+[
+  {
+    "id": "great-cta",
+    "image": "name-of-file-in-cta-image-dir.jpg",
+    "url": "/my/great/page/index.html"
+  }
+]
+```
+
 ## Configuration
 You can configure the name of the data file, as well as the directory in which the images are stored.
 

--- a/lib/cta/extension.rb
+++ b/lib/cta/extension.rb
@@ -37,7 +37,7 @@ module CTA
 
         options[:class] ||= 'cta-image'
 
-        link_to result.url, class: 'cta-link' do
+        link_to result.url_for(sitemap), class: 'cta-link' do
           image_tag(File.join(cta_controller.options.cta_directory, result.image), options)
         end
       end

--- a/lib/cta/instance.rb
+++ b/lib/cta/instance.rb
@@ -7,5 +7,12 @@ module CTA
         self.public_send("#{ key }=", value)
       end
     end
+
+    def url_for(sitemap)
+      uri = URI(url)
+      return url if uri.absolute?
+
+      sitemap.find_resource_by_path(url)
+    end
   end
 end


### PR DESCRIPTION
If providing an absolute URL, then link directly. Otherwise find the
link relative using the sitemap.